### PR TITLE
NXP-26697: Use true region name

### DIFF
--- a/ftest/webdriver/itests.xml
+++ b/ftest/webdriver/itests.xml
@@ -21,7 +21,7 @@
     </antcall>
     <antcall target="set-conf">
       <param name="name" value="nuxeo.s3storage.region" />
-      <param name="value" value="EU" />
+      <param name="value" value="eu-west-1" />
     </antcall>
   </target>
 


### PR DESCRIPTION
Backport for 8.10